### PR TITLE
Adjust wait time uri to use latest

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import csv from 'csvtojson';
 import Mapbox from './map';
 import Info from './info.js';
 
-const timesURL = "https://gist.githubusercontent.com/ctbarna/98b660129b01a5a2c050f3bab78aad70/raw/8ed0a23d8c0853e3886407e9a30b4c1b83fd8457/wait.csv"
+const timesURL = "https://gist.githubusercontent.com/ctbarna/98b660129b01a5a2c050f3bab78aad70/raw/wait.csv"
 let map, info;
 
 let state = {


### PR DESCRIPTION
Existing URI for the wait times is a specific revision of the gist,
provided in the raw format. The new URI is the raw version of the
current/latest revision. This is also the URI currently in use on the site,
at least according to the code (it appear to run server side?).

File is left with no data (headers only) during overnight periods, to trigger a front-end change in testinglines.nyc